### PR TITLE
move 'mocha' to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,8 @@
     "grunt-release": "^0.11.0",
     "grunt-templates-dylang": "^1.0.10",
     "load-grunt-tasks": "^3.1.0",
-    "time-grunt": "^1.1.0"
-  },
-  "license": "MIT",
-  "dependencies": {
+    "time-grunt": "^1.1.0",
     "mocha": "^2.2.1"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Refer to https://docs.npmjs.com/files/package.json#dependencies
I can't install this package on our production boxes which mocha is not allowed to be installed on