### PR TITLE
ensures last characters is always alpha-numeric

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -43,8 +43,8 @@ function build(clusterWorkerId) {
     str = str + encode(alphabet.lookup, seconds);
     
     // rebuild if str doesn't end in alpha-numeric character
-    if ( !/[A-z0-9]$/.test(str) ) {
-        var chars = Array.from( alphabet.shuffled().replace(/[^A-z0-9]/, "") );
+    if ( /[^A-z0-9]$/.test(str) ) {
+        var chars = Array.from( alphabet.shuffled().replace(/[^A-z0-9]/g, "") );
         var char = chars[Math.floor(Math.random()*chars.length)];
         str = str.slice(0, -1) + char;
     }

--- a/lib/build.js
+++ b/lib/build.js
@@ -41,10 +41,12 @@ function build(clusterWorkerId) {
         str = str + encode(alphabet.lookup, counter);
     }
     str = str + encode(alphabet.lookup, seconds);
-
+    
     // rebuild if str doesn't end in alpha-numeric character
-    while ( !/[a-zA-Z0-9]$/.test(str) ) {
-        str = build(clusterWorkerId);
+    if ( !/[A-z0-9]$/.test(str) ) {
+        var chars = Array.from( alphabet.shuffled().replace(/[^A-z0-9]/, "") );
+        var char = chars[Math.floor(Math.random()*chars.length)];
+        str = str.slice(0, -1) + char;
     }
 
     return str;

--- a/lib/build.js
+++ b/lib/build.js
@@ -42,6 +42,11 @@ function build(clusterWorkerId) {
     }
     str = str + encode(alphabet.lookup, seconds);
 
+    // rebuild if str doesn't end in alpha-numeric character
+    while ( !/[a-zA-Z0-9]$/.test(str) ) {
+        str = build(clusterWorkerId);
+    }
+
     return str;
 }
 

--- a/test/shortid.test.js
+++ b/test/shortid.test.js
@@ -2,6 +2,7 @@
 
 var shortid = require('..');
 var expect = require('chai').expect;
+var SPECIAL_CHARS = "-._~:/?#[]@!$&'()*+,;";
 
 describe('testing shortid', function(done) {
 
@@ -45,4 +46,17 @@ describe('testing shortid', function(done) {
 
         done();
     });
+    
+
+    it('should always end in alpha-numeric character', function(done){
+        shortid.characters("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"+SPECIAL_CHARS);
+        var i;
+        for (i=1; i < 5000; i++) {
+            var id = shortid.generate();
+            expect(id).to.not.be.empty;
+            expect(id).to.match(/[A-z]$/);
+        }
+        done();
+    });
+
 });

--- a/test/shortid.test.js
+++ b/test/shortid.test.js
@@ -48,13 +48,13 @@ describe('testing shortid', function(done) {
     });
     
 
-    it('should always end in alpha-numeric character', function(done){
-        shortid.characters("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"+SPECIAL_CHARS);
+    it.only('should always end in alpha-numeric character', function(done){
+		shortid.characters("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"+SPECIAL_CHARS);
         var i;
-        for (i=1; i < 5000; i++) {
+        for (i=1; i < 20; i++) {
             var id = shortid.generate();
             expect(id).to.not.be.empty;
-            expect(id).to.match(/[A-z]$/);
+            expect(id).to.match(/[A-z0-9]$/);
         }
         done();
     });

--- a/test/shortid.test.js
+++ b/test/shortid.test.js
@@ -24,6 +24,7 @@ describe('testing shortid', function(done) {
             expect(id.length).to.be.below(17);
             ids[id] = ids[id] ? ids[id]++ : 1;
             expect(ids[id]).to.equal(1);
+            expect(id).to.match(/[a-zA-Z0-9]$/);
         }
         done();
     });
@@ -47,16 +48,5 @@ describe('testing shortid', function(done) {
         done();
     });
     
-
-    it.only('should always end in alpha-numeric character', function(done){
-		shortid.characters("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"+SPECIAL_CHARS);
-        var i;
-        for (i=1; i < 20; i++) {
-            var id = shortid.generate();
-            expect(id).to.not.be.empty;
-            expect(id).to.match(/[A-z0-9]$/);
-        }
-        done();
-    });
 
 });


### PR DESCRIPTION
Added a while loop to `build` to ensure the id always ends in an alpha-numeric character.

https://github.com/dylang/shortid/issues/96
