### PR TITLE
feat(alphabet): avoid Array.prototype.filter

### DIFF
--- a/lib/alphabet.js
+++ b/lib/alphabet.js
@@ -29,9 +29,16 @@ function setCharacters(_alphabet_) {
         throw new Error('Custom alphabet for shortid must be ' + ORIGINAL.length + ' unique characters. You submitted ' + _alphabet_.length + ' characters: ' + _alphabet_);
     }
 
-    var unique = _alphabet_.split('').filter(function(item, ind, arr){
-       return ind !== arr.lastIndexOf(item);
-    });
+    // For compatibility with Prototype < 1.7, avoid Array.prototype.filter
+    var chars = _alphabet_.split('');
+    var unique = [];
+    for (var i = 0; i < chars.length; i++) {
+       if ((function(item, ind, arr){
+           return ind !== arr.lastIndexOf(item);
+       })(chars[i], i, chars)) {
+           unique.push(chars[i]);
+       };
+    }
 
     if (unique.length) {
         throw new Error('Custom alphabet for shortid must be ' + ORIGINAL.length + ' unique characters. These characters were not unique: ' + unique.join(', '));


### PR DESCRIPTION
Use a `for` loop instead of `Array.prototype.filter` for better compatibility with browsers/libraries that may not have that method, or may define it in an incompatible way (e.g. Prototype 1.6).