### PR TITLE
Add deprecation notice to project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## shortid  [![Build Status](http://img.shields.io/travis/dylang/shortid.svg)](https://travis-ci.org/dylang/shortid) [![shortid](http://img.shields.io/npm/dm/shortid.svg)](https://www.npmjs.org/package/shortid)
 
+
+
 > Amazingly short non-sequential url-friendly unique id generator.
 
-
-
-
+## **shortid is deprecated, because the architecture is unsafe. we instead recommend [Nano ID](https://github.com/ai/nanoid/), which has the advantage of also being significantly faster than shortid**
 
 
 


### PR DESCRIPTION
hi, i'd just installed and started to use shortid when i came across this [comment on a github issue](https://github.com/dylang/shortid/issues/148#issuecomment-529720277) that says it has been deprecated in favour of nanoid. it was only chance that i happened across the github issue, and i wouldn't have realised otherwise. so thought i'd add this notice to the readme!
